### PR TITLE
bugfix for Java classpath issue

### DIFF
--- a/src/main/scala/de/element34/sbteclipsify/ClasspathFile.scala
+++ b/src/main/scala/de/element34/sbteclipsify/ClasspathFile.scala
@@ -160,12 +160,12 @@ class ClasspathFile(project: Project, log: Logger) {
 	def getJavaPaths: List[ClasspathEntry] = {
 	    import ClasspathConversions._
 		val paths = project.asInstanceOf[MavenStyleScalaPaths]
-	    val entries: List[ClasspathEntry] = if (paths.testJavaSourcePath.exists) {
-	    	ClasspathEntry(Source, paths.testJavaSourcePath.projectRelativePath, FilterChain(IncludeFilter("**/*.java"))) :: Nil
+		  val entries: List[ClasspathEntry] = if (paths.mainJavaSourcePath.exists) {
+	    	ClasspathEntry(Source, paths.mainJavaSourcePath.projectRelativePath, FilterChain(IncludeFilter("**/*.java"))) :: Nil
 	    } else Nil
-
-	    if (paths.mainJavaSourcePath.exists) {
-	    	ClasspathEntry(Source, paths.mainJavaSourcePath.projectRelativePath, paths.testCompilePath.projectRelativePath, FilterChain(IncludeFilter("**/*.java"))) :: entries
+		
+	     if (paths.testJavaSourcePath.exists) {
+	    	ClasspathEntry(Source, paths.testJavaSourcePath.projectRelativePath, paths.testCompilePath.projectRelativePath, FilterChain(IncludeFilter("**/*.java"))) :: entries
 	    } else entries
 	}
 


### PR DESCRIPTION
Hi,

in the generated eclipse project's classpath, the output paths of main and test were mixed up. I think I've fixed that issue with the change in this pull request.

Best regards
Andreas
