### PR TITLE
support for pure-Java project

### DIFF
--- a/src/main/scala/de/element34/sbteclipsify/ClasspathFile.scala
+++ b/src/main/scala/de/element34/sbteclipsify/ClasspathFile.scala
@@ -68,12 +68,7 @@ class ClasspathFile(project: Project, log: Logger) {
     	val dependencies = basicScalaPaths.dependencyPath
     	val managedDependencies = basicScalaPaths.managedDependencyPath
 
-    	val entries = getJavaPaths ++ getScalaPaths ++ getProjectPath ++ getSbtJarForSbtProject ++
-	      			  getDependencyEntries(dependencies) ++ getDependencyEntries(managedDependencies) ++
-	      			  getPluginEntries ++
-	      			  List(ClasspathEntry(Container, scalaContainer),
-	      			  ClasspathEntry(Container, javaContainer),
-	      			  ClasspathEntry(Output, project.asInstanceOf[MavenStyleScalaPaths].mainCompilePath.projectRelativePath))
+    	val entries = buildEntries(dependencies, managedDependencies)
 
 	    lazy val classpathContent = """<?xml version="1.0" encoding="UTF-8" ?>""" +
 	    	"\n<classpath>" +
@@ -81,6 +76,22 @@ class ClasspathFile(project: Project, log: Logger) {
 	    	"\n</classpath>"
 	    createOrReplaceWith(classpathContent)
   	}
+  	
+  def buildEntries(dependencies: Path, managedDependencies: Path) = get(_.eclipseProjectNature) match {
+    case ProjectNature.Scala => 
+      getJavaPaths ++ getScalaPaths ++ getProjectPath ++ getSbtJarForSbtProject ++
+	    getDependencyEntries(dependencies) ++ getDependencyEntries(managedDependencies) ++
+	    getPluginEntries ++
+	    List(ClasspathEntry(Container, scalaContainer),
+	    ClasspathEntry(Container, javaContainer),
+	    ClasspathEntry(Output, project.asInstanceOf[MavenStyleScalaPaths].mainCompilePath.projectRelativePath))
+    case ProjectNature.Java => 
+      getJavaPaths ++ getProjectPath ++
+	    getDependencyEntries(dependencies) ++ getDependencyEntries(managedDependencies) ++
+	    getPluginEntries ++
+	    List(ClasspathEntry(Container, javaContainer),
+	    ClasspathEntry(Output, project.asInstanceOf[MavenStyleScalaPaths].mainCompilePath.projectRelativePath))
+  }
 
 	/**
 	 * replaces the current content of the .classpath file

--- a/src/main/scala/de/element34/sbteclipsify/ProjectFile.scala
+++ b/src/main/scala/de/element34/sbteclipsify/ProjectFile.scala
@@ -47,6 +47,7 @@ class ProjectFile(project: Project, log: Logger) {
 	import Utils._
 
     val scalaBuilder = "org.scala-ide.sdt.core.scalabuilder"
+    val javaBuilder = "org.eclipse.jdt.core.javabuilder"
     val manifestBuilder = "org.eclipse.pde.ManifestBuilder"
     val schemaBuilder = "org.eclipse.pde.SchemaBuilder"
     val scalaNature = "org.scala-ide.sdt.core.scalanature"
@@ -61,17 +62,31 @@ class ProjectFile(project: Project, log: Logger) {
   <projects>{createSubProjects}</projects>
   <buildSpec>
     <buildCommand>
-      <name>{scalaBuilder}</name>
+      <name>{getBuilderName}</name>
     </buildCommand>
     {getPluginXml}
   </buildSpec>
   <natures>
-    <nature>{scalaNature}</nature>
-    <nature>{javaNature}</nature>
+    {getMainNatures}
     {getPluginNature}
   </natures>
 </projectDescription>
 
+  def getBuilderName = get(_.eclipseProjectNature) match {
+    case ProjectNature.Scala => scalaBuilder
+    case ProjectNature.Java => javaBuilder
+  }
+
+  def getMainNatures = get(_.eclipseProjectNature) match {
+    case ProjectNature.Scala => writeNodeSeq { _ =>
+      <nature>{scalaNature}</nature>
+      <nature>{javaNature}</nature>
+    }
+    case ProjectNature.Java => writeNodeSeq { _ =>
+      <nature>{javaNature}</nature>
+    }
+  }
+  
 	def getPluginNature: NodeSeq = writeNodeSeq(get(_.pluginProject)){ _ =>
 		<nature>{pluginNature}</nature>
 	}

--- a/src/main/scala/de/element34/sbteclipsify/ProjectNature.scala
+++ b/src/main/scala/de/element34/sbteclipsify/ProjectNature.scala
@@ -1,0 +1,6 @@
+package de.element34.sbteclipsify
+
+object ProjectNature extends Enumeration {
+  val Scala = Value("scala") // used by default
+  val Java = Value("java")
+}

--- a/src/main/scala/de/element34/sbteclipsify/SbtEclipsify.scala
+++ b/src/main/scala/de/element34/sbteclipsify/SbtEclipsify.scala
@@ -53,6 +53,13 @@ trait Eclipsify extends Project {
   lazy val pluginProject = propertyOptional[Boolean](false)
 //  lazy val customSrcPattern = propertyOptional[RegEx]()
 
+  implicit lazy val projectNatureFormat = new Format[ProjectNature.Value] {
+    def fromString(nature: String) = ProjectNature.valueOf(nature).getOrElse(ProjectNature.Scala)
+    def toString(nature: ProjectNature.Value) = nature.toString
+  }
+
+  lazy val eclipseProjectNature = propertyOptional[ProjectNature.Value](ProjectNature.Scala)
+  
   def findProjects(log: Logger): List[Project] = {
     Nil
   }


### PR DESCRIPTION
Hi,

I've went ahead and added support for pure Java projects to your lovely plug-in. We use sbt here at work to build a pure Java project, so if you like the changes and would add them to your plug-in, that would be great.

I've added a build property "eclipse.project.nature" to control the behaviour. Valid values are "scala" or "java" at the moment, or you can of course leave the property out to default to scala nature.

Hoping you like the changes.

Kind regards
Andreas
